### PR TITLE
Improve USD support for check requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1236,7 +1236,7 @@ const schema = {
                   type: "string",
                   enum: [
                     "ACH",
-                    "checking"
+                    "Check by post"
                   ]
                 }
               },
@@ -1297,13 +1297,15 @@ const schema = {
                         address_zipcode: {
                           title: "ZIP Code",
                           type: "string"
+                        },
+                        address_country: {
+                          title: "Country",
+                          type: "string"
                         }
                       },
                       required: [
                         "address_line_one",
-                        "address_line_two",
                         "address_city",
-                        "address_state",
                         "address_zipcode"
                       ]
                     }


### PR DESCRIPTION
It's a "check" (not "checking", which is an account type).

Make address 2 optional since some only have one line.

Make state optional and add country (optional) since we can
send USD checks to other countries, e.g. Canada.